### PR TITLE
Update dataSelectors.js

### DIFF
--- a/lib/dataSelectors.js
+++ b/lib/dataSelectors.js
@@ -62,6 +62,11 @@ module.exports = {
     return $('video.landscape source').attr('src');
   },
 
+  // @return {String} thumbURL
+  generalThumbURL: function ($) {
+    return $(".project-image img").eq(0).attr('src');
+  },
+
   // @return {String} city
   locationCity: function ($) {
     return $('a.grey-dark.mr3.nowrap b').eq(0).text().split(', ')[0];


### PR DESCRIPTION
Add generalThumbURL which returns the URL of the project's main thumbnail image, currently missing (as per [issue 28](https://github.com/ghostsnstuff/kickstarter-crawler/issues/28))
